### PR TITLE
Update version of amazon-kinesis-client to v1.4.0

### DIFF
--- a/bin/kcl-bootstrap
+++ b/bin/kcl-bootstrap
@@ -47,8 +47,6 @@ var MAVEN_PACKAGE_LIST = [
   getMavenPackageInfo('com.fasterxml.jackson.core', 'jackson-annotations', '2.1.1')
 ];
 
-];
-
 var DEFAULT_JAR_PATH = path.resolve(path.join(__dirname, '..', 'lib', 'jars'));
 var MULTI_LANG_DAEMON_CLASS = 'com.amazonaws.services.kinesis.multilang.MultiLangDaemon';
 var MAX_HTTP_REDIRECT_FOLLOW = 3;

--- a/bin/kcl-bootstrap
+++ b/bin/kcl-bootstrap
@@ -31,14 +31,22 @@ var util = require('util');
 var MAVEN_PACKAGE_LIST = [
   getMavenPackageInfo('commons-codec', 'commons-codec', '1.3'),
   getMavenPackageInfo('joda-time', 'joda-time', '2.4'),
-  getMavenPackageInfo('com.amazonaws', 'aws-java-sdk', '1.7.13'),
+  getMavenPackageInfo('com.amazonaws', 'aws-java-sdk-core', '1.10.11'),
+  getMavenPackageInfo('com.amazonaws', 'aws-java-sdk-kinesis', '1.10.11'),
+  getMavenPackageInfo('com.amazonaws', 'aws-java-sdk-dynamodb', '1.10.11'),
+  getMavenPackageInfo('com.amazonaws', 'aws-java-sdk-cloudwatch', '1.10.11'),
+  getMavenPackageInfo('com.google.guava', 'guava', '18.0'),
+  getMavenPackageInfo('com.google.protobuf', 'protobuf-java', '2.6.1'),
+  getMavenPackageInfo('commons-lang', 'commons-lang', '2.6'),
   getMavenPackageInfo('com.fasterxml.jackson.core', 'jackson-databind', '2.1.1'),
   getMavenPackageInfo('commons-logging', 'commons-logging', '1.1.1'),
-  getMavenPackageInfo('com.amazonaws', 'amazon-kinesis-client', '1.2.0'),
+  getMavenPackageInfo('com.amazonaws', 'amazon-kinesis-client', '1.4.0'),
   getMavenPackageInfo('com.fasterxml.jackson.core', 'jackson-core', '2.1.1'),
   getMavenPackageInfo('org.apache.httpcomponents', 'httpclient', '4.2'),
   getMavenPackageInfo('org.apache.httpcomponents', 'httpcore', '4.2'),
   getMavenPackageInfo('com.fasterxml.jackson.core', 'jackson-annotations', '2.1.1')
+];
+
 ];
 
 var DEFAULT_JAR_PATH = path.resolve(path.join(__dirname, '..', 'lib', 'jars'));


### PR DESCRIPTION
The module ships with version 1.2.0 of the amazon-kinesis-client package which doesn't support the aggregation features available in later versions. This pull request updates the package to 1.4.0 which adds the aggregation support. 

This build works for me on Mac OS X 10.10 and EC2 Linux. Versions of the amazon-kinesis-client older than 1.4 don't work on EC2 linux by default as they appear to be compiled with Java 1.8, whereas EC2 Linux ships with 1.7/ 

I've updated the supporting packages as well, though I'm not 100% sure about which version of the original packages are still required. 