### PR TITLE
Handled Changed Field Names

### DIFF
--- a/lib/kcl/kcl_manager.js
+++ b/lib/kcl/kcl_manager.js
@@ -202,7 +202,7 @@ KCLManager.prototype.checkpoint = function(sequenceNumber) {
   // Before invoking operation, first transition to make sure state is valid.
   this._handleStateInput(this._context, 'beginCheckpoint');
 
-  this._sendAction(this._context, {action : 'checkpoint', checkpoint : sequenceNumber});
+  this._sendAction(this._context, {action : 'checkpoint', sequenceNumber : sequenceNumber});
 };
 
 /**
@@ -306,7 +306,7 @@ KCLManager.prototype._onCheckpointAction = function(action) {
   this._handleStateInput(this._context, 'finishCheckpoint');
 
   var checkpointer = this._context.checkpointer;
-  checkpointer.onCheckpointerResponse.apply(checkpointer, [action.error, action.checkpoint]);
+  checkpointer.onCheckpointerResponse.apply(checkpointer, [action.error, action.sequenceNumber]);
 };
 
 /**


### PR DESCRIPTION
The 1.7.2 Update of the Amazon Kinesis Client changed the field name for
the sequence number from 'checkpoint' to 'sequenceNumber'.