### PR TITLE
Multiple properties files

### DIFF
--- a/bin/kcl-bootstrap
+++ b/bin/kcl-bootstrap
@@ -67,25 +67,27 @@ function bootstrap() {
 
 function parseArguments() {
   program
-    .option('-p, --properties <properties file>', 'properties file with multi-language daemon options')
+    .option('-p, --properties <properties files>', 'properties files (separated by commas) with multi-language daemon options')
     .option('-j, --java [java path]', 'path to java executable - defaults to using JAVA_HOME environment variable to get java path (optional)')
     .option('-c, --jar-path [jar path]', 'path where all multi-language daemon jar files will be downloaded (optional)')
     .option('-e, --execute', 'execute the KCL application')
     .parse(process.argv);
 
   var args = {
-    'properties': program.properties,
+    'properties': program.properties.split(','),
     'java': (program.java ? program.java : (process.env.JAVA_HOME ? path.join(process.env.JAVA_HOME, 'bin', 'java') : null)),
     'jarPath': (program.jarPath ? program.jarPath : DEFAULT_JAR_PATH),
     'execute': program.execute
   };
 
-  if (!args.properties) {
+  if (!args.properties && args.properties.length < 1) {
     invalidInvocationExit(program, 'Specify a valid --properties value.', true);
   }
-  if (!isFile(args.properties)) {
-    invalidInvocationExit(program, args.properties + ' file does not exist. Specify a valid --properties value.', true);
-  }
+  args.properties.forEach(function (propFile) {
+    if (!isFile(propFile)) {
+      invalidInvocationExit(program, propFile + ' file does not exist. Specify a valid --properties value.', true);
+    }
+  });
   if (!isFile(args.java)) {
     invalidInvocationExit(program, 'Valid --java value is required or alternatively JAVA_HOME environment variable must be set.', true);
   }
@@ -99,21 +101,33 @@ function parseArguments() {
 }
 
 function startKinesisClientLibraryApplication(options) {
-  var classpath = getClasspath(options).join(getPathDelimiter());
   var java = options.java;
-  var args = ['-cp', classpath, MULTI_LANG_DAEMON_CLASS, options.properties];
-  var cmd = java + ' ' + args.join(' ');
+  options.properties.forEach(function (propFile, index) {
+    var classpath = getClasspath(options, propFile).join(getPathDelimiter());
+    var args = ['-cp', classpath, MULTI_LANG_DAEMON_CLASS, propFile];
+    var cmd = java + ' ' + args.join(' ');
 
-  console.log("==========================================================");
-  console.log(cmd);
-  console.log("==========================================================");
-  if (options.execute) {
-    console.log("Starting Multi-Lang Daemon ...");
-    spawn(java, args, { stdio: 'inherit' });
-  }
+    console.log('( ' + index + ' ) ==========================================================');
+    console.log('( ' + index + ' ) ' + cmd);
+    console.log('( ' + index + ' ) ==========================================================');
+    if (options.execute) {
+      console.log('( ' + index + ' ) Starting Multi-Lang Daemon ...');
+      // var p = spawn(java, args, { stdio: 'inherit' }); // defining stdio, makes stdout/err null
+      var p = spawn(java, args);
+      p.stdout.on('data', function (data) {
+        console.log('(' + index + ') ' + data);
+      });
+      p.stderr.on('data', function (data) {
+        console.log('(' + index + ') ' + data);
+      });
+      p.on('close', function (code) {
+        console.log('(' + index + ') Multi-Lang Daemon exited with code: ' + code);
+      });
+    }
+  });
 }
 
-function getClasspath(options) {
+function getClasspath(options, propFile) {
   var classpath = [];
   fs.readdirSync(options.jarPath).map(function (file) {
     return path.join(options.jarPath, file);
@@ -123,7 +137,7 @@ function getClasspath(options) {
     classpath.push(path.resolve(file));
   });
   classpath.push(path.resolve('.'));
-  classpath.push(path.dirname(path.resolve(options.properties)));
+  classpath.push(path.dirname(path.resolve(propFile)));
   return classpath;
 }
 

--- a/bin/kcl-bootstrap
+++ b/bin/kcl-bootstrap
@@ -29,16 +29,25 @@ var util = require('util');
 
 
 var MAVEN_PACKAGE_LIST = [
-  getMavenPackageInfo('commons-codec', 'commons-codec', '1.3'),
-  getMavenPackageInfo('joda-time', 'joda-time', '2.4'),
-  getMavenPackageInfo('com.amazonaws', 'aws-java-sdk', '1.7.13'),
-  getMavenPackageInfo('com.fasterxml.jackson.core', 'jackson-databind', '2.1.1'),
-  getMavenPackageInfo('commons-logging', 'commons-logging', '1.1.1'),
-  getMavenPackageInfo('com.amazonaws', 'amazon-kinesis-client', '1.2.0'),
-  getMavenPackageInfo('com.fasterxml.jackson.core', 'jackson-core', '2.1.1'),
-  getMavenPackageInfo('org.apache.httpcomponents', 'httpclient', '4.2'),
-  getMavenPackageInfo('org.apache.httpcomponents', 'httpcore', '4.2'),
-  getMavenPackageInfo('com.fasterxml.jackson.core', 'jackson-annotations', '2.1.1')
+  getMavenPackageInfo('commons-codec', 'commons-codec', '1.9'),
+  getMavenPackageInfo('commons-logging', 'commons-logging', '1.1.3'),
+  getMavenPackageInfo('commons-lang', 'commons-lang', '2.6'),
+  getMavenPackageInfo('joda-time', 'joda-time', '2.8.1'),
+  getMavenPackageInfo('com.amazonaws', 'aws-java-sdk-core', '1.11.14'),
+  getMavenPackageInfo('com.amazonaws', 'aws-java-sdk-cloudwatch', '1.11.14'),
+  getMavenPackageInfo('com.amazonaws', 'aws-java-sdk-dynamodb', '1.11.14'),
+  getMavenPackageInfo('com.amazonaws', 'aws-java-sdk-kinesis', '1.11.14'),
+  getMavenPackageInfo('com.amazonaws', 'aws-java-sdk-kms', '1.11.14'),
+  getMavenPackageInfo('com.amazonaws', 'aws-java-sdk-s3', '1.11.14'),
+  getMavenPackageInfo('com.amazonaws', 'amazon-kinesis-client', '1.7.2'),
+  getMavenPackageInfo('com.fasterxml.jackson.core', 'jackson-databind', '2.6.6'),
+  getMavenPackageInfo('com.fasterxml.jackson.core', 'jackson-core', '2.6.6'),
+  getMavenPackageInfo('com.fasterxml.jackson.core', 'jackson-annotations', '2.6.0'),
+  getMavenPackageInfo('com.fasterxml.jackson.dataformat', 'jackson-dataformat-cbor', '2.6.6'),
+  getMavenPackageInfo('org.apache.httpcomponents', 'httpclient', '4.5.2'),
+  getMavenPackageInfo('org.apache.httpcomponents', 'httpcore', '4.4.4'),
+  getMavenPackageInfo('com.google.guava', 'guava', '18.0'),
+  getMavenPackageInfo('com.google.protobuf', 'protobuf-java', '2.6.1')
 ];
 
 var DEFAULT_JAR_PATH = path.resolve(path.join(__dirname, '..', 'lib', 'jars'));


### PR DESCRIPTION
With one invocation of the kcl-bootstrap, this is a simple way to allow for the equivalent of multiple event triggers on a lambda. You can now specify a comma separated list of kcl.properties files, each will spawn a separate Java process running the amazon-kinesis-client. The console output does overlap unfortunately; there is a index appended to the beginning of each log output to help narrow down which logs message comes from which process (properties file configuration).