### PR TITLE
Fetch Maven packages over HTTPS rather than HTTP

### DIFF
--- a/bin/kcl-bootstrap
+++ b/bin/kcl-bootstrap
@@ -217,7 +217,7 @@ function getMavenPackageUrlInfo(mavenPackage) {
   urlParts.push(mavenPackage.version);
   urlParts.push(fileName);
   return {
-    'url': "http://search.maven.org/remotecontent?filepath=" + urlParts.join('/'),
+    'url': "https://search.maven.org/remotecontent?filepath=" + urlParts.join('/'),
     'fileName': fileName
   };
 }


### PR DESCRIPTION
search.maven.org supports HTTPS, we should be using that to transport
jars for obvious reasons.