### PR TITLE
Add support for 'win32' platform

### DIFF
--- a/bin/kcl-bootstrap
+++ b/bin/kcl-bootstrap
@@ -108,6 +108,10 @@ function bootstrap() {
   });
 }
 
+function createJavaHomeExecutablePath() {
+  return path.join(process.env.JAVA_HOME, 'bin', process.platform !== 'win32' ? 'java' : 'java.exe');
+}
+
 function parseArguments() {
   program
     .option('-p, --properties [properties file]', 'properties file with multi-language daemon options')
@@ -120,7 +124,7 @@ function parseArguments() {
   var args = {
     'properties': program.properties,
     'logConfiguration': program.logConfiguration ? program.logConfiguration: null,
-    'java': (program.java ? program.java : (process.env.JAVA_HOME ? path.join(process.env.JAVA_HOME, 'bin', 'java') : null)),
+    'java': (program.java ? program.java : (process.env.JAVA_HOME ? createJavaHomeExecutablePath() : null)),
     'jarPath': (program.jarPath ? program.jarPath : DEFAULT_JAR_PATH),
     'execute': program.execute
   };
@@ -147,14 +151,10 @@ function parseArguments() {
 }
 
 function startKinesisClientLibraryApplication(options) {
-  var classpath = '-cp ' + getClasspath(options).join(getPathDelimiter());
+  var classpath = getClasspath(options).join(getPathDelimiter());
   var java = options.java;
-  var propertiesFile = '--properties-file ' + options.properties;
-  var logConfiguration = '';
-  if (options.logConfiguration) {
-    logConfiguration = '--log-configuration ' + options.logConfiguration;
-  }
-  var args = [classpath, MULTI_LANG_DAEMON_CLASS, propertiesFile, logConfiguration];
+  var logConfiguration = options.logConfiguration ? ['--log-configuration', options.logConfiguration] : [];
+  var args = ['-cp', classpath, MULTI_LANG_DAEMON_CLASS, '--properties-file', options.properties, ...logConfiguration];
   var cmd = java + ' ' + args.join(' ');
 
   console.log("==========================================================");


### PR DESCRIPTION
*Add support for windows environment*

Currently it's not possible to run kcl-bootstrap on machine with windows OS. These changes adds support for JAVA_HOME env usage and fixes spawn invocation.