### PR TITLE
Handling shutdown action again

### DIFF
--- a/lib/kcl/kcl_manager.js
+++ b/lib/kcl/kcl_manager.js
@@ -53,6 +53,7 @@ KCLManager.prototype._onAction = function(action) {
   switch (actionType) {
     case 'initialize':
     case 'processRecords':
+    case 'shutdown':
     case 'leaseLost':
     case 'shardEnded':
       this._onRecordProcessorAction(action);

--- a/lib/kcl/kcl_manager.js
+++ b/lib/kcl/kcl_manager.js
@@ -26,7 +26,7 @@ KCLManager.VERSION2 = Symbol("version2");
  * @param {object} kclManagerInput - Object containing the recordprocessor and the version of the record processor.
  * @param {file} inputFile - A file to read action messages from.
  * @param {file} outputFile - A file to write action messages to.
- * @param {file} errorfile - A file to write error messages to.
+ * @param {file} errorFile - A file to write error messages to.
  */
 function KCLManager(kclManagerInput, inputFile, outputFile, errorFile) {
   this._version = kclManagerInput.version;

--- a/lib/kcl/kcl_process.js
+++ b/lib/kcl/kcl_process.js
@@ -60,7 +60,7 @@ var KCLManager = require('./kcl_manager');
  * @param {object} recordProcessor - A record processor to use for processing a shard.
  * @param {file} inputFile - A file to read action messages from. Defaults to STDIN.
  * @param {file} outputFile - A file to write action messages to. Defaults to STDOUT.
- * @param {file} errorfile - A file to write error messages to. Defaults to STDERR.
+ * @param {file} errorFile - A file to write error messages to. Defaults to STDERR.
  */
 function KCLProcess(recordProcessor, inputFile, outputFile, errorFile) {
   var allMethodsPresent = typeof recordProcessor.initialize === 'function' &&
@@ -84,7 +84,7 @@ function KCLProcess(recordProcessor, inputFile, outputFile, errorFile) {
     version: version
   };
 
-  var kclManager = new KCLManager(kclManagerInput, inputFile, outputFile, errorFile, version);
+  var kclManager = new KCLManager(kclManagerInput, inputFile, outputFile, errorFile);
 
   return {
     // For testing only.


### PR DESCRIPTION
*Related to https://github.com/awslabs/amazon-kinesis-client-nodejs/issues/71*

*Description of changes:*
Added in handling of shutdown action which was removed in this commit https://github.com/awslabs/amazon-kinesis-client-nodejs/commit/a2be81a3bd4ccca7f68b616ebc416192c3be9d0e#diff-8ce633fa6b02f49aa98f6aaf35fc7d6bL245

I also fixed up some js doc and corrected arg passing to the KCLManager (it had one extra arg for some reason)

The error logging is still broken https://github.com/awslabs/amazon-kinesis-client-nodejs/issues/71#issue-478978562
Had a look at the repo history and I think it never ever worked

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
