### PR TITLE
Fix https protocol detection

### DIFF
--- a/bin/kcl-bootstrap
+++ b/bin/kcl-bootstrap
@@ -210,7 +210,7 @@ function httpDownloadFile(requestUrl, destinationFile, redirectCount, callback) 
     callback('Reached maximum redirects. ' + requestUrl + ' could not be downloaded.');
     return;
   }
-  var protocol = (url.parse(requestUrl).protocol === 'https' ? https : http);
+  var protocol = (url.parse(requestUrl).protocol === 'https:' ? https : http);
   var options = {
     hostname: url.parse(requestUrl).hostname,
     path: url.parse(requestUrl).path,


### PR DESCRIPTION
This PR fixes the _kcl-bootstrap_ script, that is not working anymore on our CI since a few hours.

The root cause is pretty straight forward (and frightening): the script does not respect the URL scheme, and *never* use _https_ while downloading dependencies.

The issue raised because Maven repository does not accept _http_ requests anymore.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._