### PR TITLE
kcl-bootstrap: recursively make directories.

### DIFF
--- a/bin/kcl-bootstrap
+++ b/bin/kcl-bootstrap
@@ -229,7 +229,7 @@ function isDirectory(path) {
 
 function createDirectory(path) {
   try {
-    fs.mkdirSync(path);
+    fs.mkdirSync(path, {'recursive': true});
   } catch (e) {
     if (e.code !== 'EEXIST') {
       throw e;


### PR DESCRIPTION
*Description of changes:*

When starting `kcl-bootstrap` for the first time, it may error out if there is not already a `lib` directory (since it attempts to make `lib/jars`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
