### PR TITLE
Add aws-java-sdk-sts module 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,4 +351,4 @@
             <version>3.2.2</version>
         </dependency>
     </dependencies>
-</project> 
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,11 @@
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.ion</groupId>
             <artifactId>ion-java</artifactId>
             <version>1.5.1</version>


### PR DESCRIPTION
*Issue #, if available:*
Similar to [this issue](https://github.com/aws/aws-sdk-java/issues/2136), to make [EKS service account IAM role](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) works, WebIdentityTokenCredentialsProvider requires `aws-java-sdk-sts` module.

*Description of changes:*

Add aws-java-sdk-sts module which is required by WebIdentityTokenCredentialsProvider

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
