### PR TITLE
Keep Java dependencies in sync with the KCL V2.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <awssdk.version>2.17.268</awssdk.version>
-        <aws-java-sdk.version>1.12.296</aws-java-sdk.version>
-        <netty.version>4.1.77.Final</netty.version>
+        <awssdk.version>2.19.2</awssdk.version>
+        <aws-java-sdk.version>1.12.370</aws-java-sdk.version>
+        <netty.version>4.1.86.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.4</fasterxml-jackson.version>
         <logback.version>1.3.0</logback.version>
@@ -13,12 +13,12 @@
         <dependency>
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-client-multilang</artifactId>
-            <version>2.4.3</version>
+            <version>2.4.4</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-client</artifactId>
-            <version>2.4.3</version>
+            <version>2.4.4</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -238,7 +238,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
+            <version>2.0.5</version>
         </dependency>
         <dependency>
             <groupId>io.reactivex.rxjava3</groupId>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Updated dependencies to match the v2.4.4 KCL Java release
- Updated slfj to resolve the logger's incompatibility problem:
    ```
    class org.slf4j.impl.SimpleLoggerFactory cannot be cast to class ch.qos.logback.classic.LoggerContext     \
    (org.slf4j.impl.SimpleLoggerFactory and ch.qos.logback.classic.LoggerContext are in unnamed module of loader 'app')
    ```

*Testing*
- npm test
- sample producer and consumer


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
