### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,11 @@
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.ion</groupId>
             <artifactId>ion-java</artifactId>
             <version>1.5.1</version>


### PR DESCRIPTION
missing sts package - not working without it

*Issue #, if available:*
I'm not sure why, but 2 SDKs are used here: 2.19.2 - which also downloads sts package, and 1.12.370 which lacks sts
I'm configuring kcl.properties file with: `AWSCredentialsProvider = WebIdentityTokenCredentialsProvider`
I'm getting this error:
```
To use assume role profiles the aws-java-sdk-sts module must be on the class path
```

*Description of changes:*
add missing package


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
