### PR TITLE
Add support for service accounts in EKS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,11 @@
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.ion</groupId>
             <artifactId>ion-java</artifactId>
             <version>1.5.1</version>


### PR DESCRIPTION
*Issue #, if available:*
Fixes #79

*Description of changes:*

As noted here https://github.com/awslabs/amazon-kinesis-client/issues/1110#issuecomment-1553528985, adding aws-java-sdk-sts to pom.xml fixes the issue of the default provider chain not putting up on service accounts.
