### PR TITLE
CVE-2022-3171: Bumps com.google.protobuf:protobuf-java from 3.21.5 to 3.21.7.

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ In this release, we have abstracted these implementation details away and expose
 
 
 ## Release Notes
+### Release 2.2.2 (October 6, 2023) 
+* [PR #277](https://github.com/awslabs/amazon-kinesis-client-nodejs/pull/277) Bumps com.google.protobuf:protobuf-java from 3.21.5 to 3.21.7.
+
 ### Release 2.2.2 (January 4, 2023)
 * [PR #207](https://github.com/awslabs/amazon-kinesis-client-nodejs/pull/207) Add endpoints-spi dependency
 

--- a/README.md
+++ b/README.md
@@ -273,9 +273,6 @@ In this release, we have abstracted these implementation details away and expose
 
 
 ## Release Notes
-### Release 2.2.2 (October 6, 2023) 
-* [PR #277](https://github.com/awslabs/amazon-kinesis-client-nodejs/pull/277) Bumps com.google.protobuf:protobuf-java from 3.21.5 to 3.21.7.
-
 ### Release 2.2.2 (January 4, 2023)
 * [PR #207](https://github.com/awslabs/amazon-kinesis-client-nodejs/pull/207) Add endpoints-spi dependency
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-kcl",
   "description": "Kinesis Client Libray (KCL) in Node.js.",
-  "version": "2.2.3",
+  "version": "2.2.2-SNAPSHOT",
   "author": {
     "name": "Amazon Web Services",
     "url": "http://aws.amazon.com/"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-kcl",
   "description": "Kinesis Client Libray (KCL) in Node.js.",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "author": {
     "name": "Amazon Web Services",
     "url": "http://aws.amazon.com/"

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.21.5</version>
+            <version>3.21.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
[CVE-2022-3171](https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)

CVE-2022-3171: Bumps com.google.protobuf:protobuf-java from 3.21.5 to 3.21.7.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
