### PR TITLE
Adding missing dependency (jar) sinve v.2.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,11 @@
             <version>${awssdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>arns</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>           
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
             <version>${netty.version}</version>
@@ -350,10 +355,5 @@
             <artifactId>commons-collections</artifactId>
             <version>3.2.2</version>
         </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>arns</artifactId>
-            <version>2.22.13</version>
-        </dependency>        
     </dependencies>
 </project> 

--- a/pom.xml
+++ b/pom.xml
@@ -350,5 +350,10 @@
             <artifactId>commons-collections</artifactId>
             <version>3.2.2</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>arns</artifactId>
+            <version>2.22.13</version>
+        </dependency>        
     </dependencies>
 </project> 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In v2.2.3 this jar was missing from the pom.xml file.
When the library starts and initially downloads the Java jars this file is missing - which causes the MultiLanguage Daemon to fail with the following error:

13:32:34.724 [multi-lang-daemon-0000] ERROR s.a.kinesis.coordinator.Scheduler - Worker.run caught exception, sleeping for 1000 milli seconds!
java.lang.RuntimeException: java.util.concurrent.ExecutionException: java.lang.NoClassDefFoundError: software/amazon/awssdk/arns/Arn
        at software.amazon.kinesis.lifecycle.ShardConsumer.executeLifecycle(ShardConsumer.java:193)
        at software.amazon.kinesis.coordinator.Scheduler.runProcessLoop(Scheduler.java:414)
        at software.amazon.kinesis.coordinator.Scheduler.run(Scheduler.java:324)
        at software.amazon.kinesis.multilang.MultiLangDaemon$MultiLangRunner.call(MultiLangDaemon.java:95)
        at software.amazon.kinesis.multilang.MultiLangDaemon$MultiLangRunner.call(MultiLangDaemon.java:86)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.util.concurrent.ExecutionException: java.lang.NoClassDefFoundError: software/amazon/awssdk/arns/Arn
        at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
        at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
        at software.amazon.kinesis.lifecycle.ShardConsumer.executeLifecycle(ShardConsumer.java:178)
        ... 8 common frames omitted
Caused by: java.lang.NoClassDefFoundError: software/amazon/awssdk/arns/Arn    <------------------- Missing JAR
        at software.amazon.kinesis.retrieval.polling.KinesisDataFetcher.advanceIteratorTo(KinesisDataFetcher.java:243)
        at software.amazon.kinesis.retrieval.polling.KinesisDataFetcher.advanceIteratorTo(KinesisDataFetcher.java:231)
        at software.amazon.kinesis.retrieval.polling.KinesisDataFetcher.initialize(KinesisDataFetcher.java:218)
        at software.amazon.kinesis.retrieval.polling.PrefetchRecordsPublisher$PublisherSession.init(PrefetchRecordsPublisher.java:125)
        at software.amazon.kinesis.retrieval.polling.PrefetchRecordsPublisher.start(PrefetchRecordsPublisher.java:273)
        at software.amazon.kinesis.lifecycle.InitializeTask.call(InitializeTask.java:84)
        at software.amazon.kinesis.lifecycle.ShardConsumer.executeTask(ShardConsumer.java:336)
        at software.amazon.kinesis.lifecycle.ShardConsumer.lambda$initializeComplete$2(ShardConsumer.java:289)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
        ... 3 common frames omitted

Adding the missing dependency fixed it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
