### PR TITLE
Add nodejs 18.x and 20.x to CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [21.x]
+        node-version: ['18.x', '20.x', '21.x']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/test/kcl/action_handler_tests.js
+++ b/test/kcl/action_handler_tests.js
@@ -79,7 +79,7 @@ describe('action_handler_tests', function() {
 
   it('should write action to stdout', function(done) {
     actionHandler.sendAction({action : 'initialize', shardId : 'shardId-000001'}, function(err) {
-      should.equal(err, null);
+      should.not.exist(err);
       expect(stdoutHook.readLast()).to.equal('{"action":"initialize","shardId":"shardId-000001"}');
       done();
     });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Adds other supported node version 18.x and 20.x from https://github.com/nodejs/release?tab=readme-ov-file#release-schedule to the CI. Also fixes a unit test to be compatible with all versions

- CI passes on fork https://github.com/lucienlu-aws/amazon-kinesis-client-nodejs/pull/4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.