### PR TITLE
Releasing KCL Node 2.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ In this release, we have abstracted these implementation details away and expose
 
 
 ## Release Notes
+### Release 2.6.1 (January 22, 2025)
+* Upgraded amazon-kinesis-client from 2.2.6 to 2.6.1
+
 ### Release 2.2.6 (April 25, 2024)
 * [PR #327](https://github.com/awslabs/amazon-kinesis-client-nodejs/pull/327) Upgraded amazon-kinesis-client from 2.5.5 to 2.5.8
 * [PR #329](https://github.com/awslabs/amazon-kinesis-client-nodejs/pull/329) Upgraded aws-sdk from 2.1562.0 to 2.1603.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-kcl",
-  "version": "2.2.6",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-kcl",
-      "version": "2.2.6",
+      "version": "2.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "~12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-kcl",
   "description": "Kinesis Client Libray (KCL) in Node.js.",
-  "version": "2.2.6",
+  "version": "2.6.1",
   "author": {
     "name": "Amazon Web Services",
     "url": "http://aws.amazon.com/"

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <kcl.version>2.5.8</kcl.version>
+        <kcl.version>2.6.1</kcl.version>
         <awssdk.version>2.25.11</awssdk.version>
         <aws-java-sdk.version>1.12.512</aws-java-sdk.version>
         <netty.version>4.1.108.Final</netty.version>


### PR DESCRIPTION
## Release 2.6.1 (January 22, 2025)
* Upgraded aws-kcl from 2.2.6 to 2.6.1