### PR TITLE
Preparing for KCL Node v2.3.0 release 

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,23 @@ In this release, we have abstracted these implementation details away and expose
 * [Amazon Kinesis documentation][amazon-kinesis-docs]
 * [Amazon Kinesis forum][kinesis-forum]
 
+## 🚨Important: Migration to Node KCL 2.3.0 (or later) with MultiLangDaemon - Credential Provider Changes Required
+Java KCL version 2.7.0 and later uses AWS SDK for Java 2.x instead of AWS SDK for Java 1.x. For the  KCL Node 2.x versions, 
+v2.3.0 is the first node release to use Java KCL 2.7.0. All MultiLangDaemon users upgrading from earlier versions must update
+their credential provider configuration in the `.properties` file to use credentials provider name for AWS SDK for Java 2.x. 
+Failure to do this will cause your multilang KCL application to fail during startup with credential provider construction errors. 
+Please check the following link for the credentials provider mapping and MultiLangDaemon credentials provider configuration guide.
+
+- [AWS SDK for Java 1.x to 2.x Credentials Provider Mapping](aws.amazon.com/sdk-for-java/latest/developer-guide/migration-client-credentials.html#credentials-changes-mapping)
+- [KCL Multilang Credentials Provider Configuration Guide](https://github.com/aws/amazon-kinesis-client/blob/master/docs/multilang/configuring-credential-providers.md)
+
 
 ## Release Notes
+### Release 2.3.0 (March 12, 2025) - IMPORTANT: See section ``Migration to Node KCL 2.3.0`` to ensure upgrading does not break compatibility
+* Upgraded amazon-kinesis-client from 2.6.1 to 2.7.0 - [Java 2.7.0 release notes](https://github.com/awslabs/amazon-kinesis-client/releases/tag/v2.7.0)
+* [PR #392](https://github.com/awslabs/amazon-kinesis-client-nodejs/pull/392) Upgraded netty from 4.1.108 to 4.1.118
+* [PR #392](https://github.com/awslabs/amazon-kinesis-client-nodejs/pull/392) Upgraded logback from 1.3.14 to 1.5.16  
+
 ### Release 2.2.7 (January 22, 2025)
 * Upgraded amazon-kinesis-client from 2.5.8 to 2.6.1 - [Java 2.6.1 release notes](https://github.com/awslabs/amazon-kinesis-client/releases/tag/v2.6.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-kcl",
-  "version": "2.2.7",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-kcl",
-      "version": "2.2.7",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "~12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-kcl",
   "description": "Kinesis Client Libray (KCL) in Node.js.",
-  "version": "2.2.7",
+  "version": "2.3.0",
   "author": {
     "name": "Amazon Web Services",
     "url": "http://aws.amazon.com/"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <properties>
         <awssdk.version>2.25.64</awssdk.version>
         <aws-java-sdk.version>1.12.668</aws-java-sdk.version>
-        <kcl.version>2.6.1</kcl.version>
+        <kcl.version>2.7.0</kcl.version>
         <netty.version>4.1.118.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
@@ -30,18 +30,6 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
             <version>${awssdk.version}</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/dynamodb-enhanced -->
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>dynamodb-enhanced</artifactId>
-            <version>${awssdk.version}</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/dynamodb-lock-client -->
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>dynamodb-lock-client</artifactId>
-            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/samples/basic_sample/consumer/sample.properties
+++ b/samples/basic_sample/consumer/sample.properties
@@ -3,7 +3,12 @@
 # over STDIN and STDOUT according to the multi-language protocol.
 executableName = node sample_kcl_app.js
 
+# The Stream arn: arn:aws:kinesis:<region>:<account id>:stream/<stream name>
+# Important: streamArn takes precedence over streamName if both are set
+# streamArn = arn:aws:kinesis:us-east-5:000000000000:stream/kclnodejssample
+
 # The name of an Amazon Kinesis stream to process.
+# Important: streamArn takes precedence over streamName if both are set
 streamName = kclnodejssample
 
 # Used by the KCL as the name of this application. Will be used as the name
@@ -27,10 +32,15 @@ processingLanguage = nodejs/0.10
 # See http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#API_GetShardIterator_RequestSyntax
 initialPositionInStream = TRIM_HORIZON
 
+# To specify an initial timestamp from which to start processing records, please specify timestamp value for 'initiatPositionInStreamExtended',
+# and uncomment below line with right timestamp value.
+# See more from 'Timestamp' under http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#API_GetShardIterator_RequestSyntax
+#initialPositionInStreamExtended = 1636609142
+
 # The following properties are also available for configuring the KCL Worker that is created
 # by the MultiLangDaemon.
 
-# Region of the stream for the KCL.
+# The KCL defaults to us-east-1
 regionName = us-east-1
 
 # Fail over time in milliseconds. A worker which does not renew it's lease within this time interval
@@ -83,95 +93,3 @@ regionName = us-east-1
 # active threads set to the provided value. If a non-positive integer or no
 # value is provided a CachedThreadPool is used.
 #maxActiveThreads = 0
-
-# By default, KCL will emit metrics for Operation, ShardId, and WorkerIdentifier dimensions
-# Specify the specific dimensions to emit metrics for
-#metricsEnabledDimensions = Operation,ShardId
-
-################### KclV3 configurations ###################
-# NOTE : These are just test configurations to show how to customize
-# all possible KCLv3 configurations. They are not necessarily the best
-# default values to use for production.
-
-# Coordinator config
-# Version the KCL needs to operate in. For more details check the KCLv3 migration
-# documentation. Default is CLIENT_VERSION_CONFIG_3X
-# clientVersionConfig =
-# Configurations to control how the CoordinatorState DDB table is created
-# Default name is applicationName-CoordinatorState in PAY_PER_REQUEST,
-# with PITR and deletion protection disabled and no tags
-# coordinatorStateTableName =
-# coordinatorStateBillingMode =
-# coordinatorStateReadCapacity =
-# coordinatorStateWriteCapacity =
-# coordinatorStatePointInTimeRecoveryEnabled =
-# coordinatorStateDeletionProtectionEnabled =
-# coordinatorStateTags =
-
-# Graceful handoff config - tuning of the shutdown behavior during lease transfers
-# default values are 30000 and true respectively
-# gracefulLeaseHandoffTimeoutMillis =
-# isGracefulLeaseHandoffEnabled =
-
-# WorkerMetricStats table config - control how the DDB table is created
-# Default name is applicationName-WorkerMetricStats in PAY_PER_REQUEST,
-# with PITR and deletion protection disabled and no tags
-# workerMetricsTableName =
-# workerMetricsBillingMode =
-# workerMetricsReadCapacity =
-# workerMetricsWriteCapacity =
-# workerMetricsPointInTimeRecoveryEnabled =
-# workerMetricsDeletionProtectionEnabled =
-# workerMetricsTags =
-
-# WorkerUtilizationAwareAssignment config - tune the new KCLv3 Lease balancing algorithm
-#
-# frequency of capturing worker metrics in memory. Default is 1s
-# inMemoryWorkerMetricsCaptureFrequencyMillis =
-
-# frequency of reporting worker metric stats to storage. Default is 30s
-# workerMetricsReporterFreqInMillis =
-
-# No. of metricStats that are persisted in WorkerMetricStats ddb table, default is 10
-# noOfPersistedMetricsPerWorkerMetrics =
-
-# Disable use of worker metrics to balance lease, default is false.
-# If it is true, the algorithm balances lease based on worker's processing throughput.
-# disableWorkerMetrics =
-
-# Max throughput per host 10 MBps, to limit processing to the given value
-# Default is unlimited.
-
-# maxThroughputPerHostKBps =
-# Dampen the load that is rebalanced during lease re-balancing, default is 60%
-# dampeningPercentage =
-# Configures the allowed variance range for worker utilization. The upper
-# limit is calculated as average * (1 + reBalanceThresholdPercentage/100).
-# The lower limit is average * (1 - reBalanceThresholdPercentage/100). If
-# any worker's utilization falls outside this range, lease re-balancing is
-# triggered. The re-balancing algorithm aims to bring variance within the
-# specified range. It also avoids thrashing by ensuring the utilization of
-# the worker receiving the load after re-balancing doesn't exceed the fleet
-# average. This might cause no re-balancing action even the utilization is
-# out of the variance range. The default value is 10, representing +/-10%
-# variance from the average value.
-# reBalanceThresholdPercentage =
-
-# Whether at-least one lease must be taken from a high utilization worker
-# during re-balancing when there is no lease assigned to that worker which has
-# throughput is less than or equal to the minimum throughput that needs to be
-# moved away from that worker to bring the worker back into the allowed variance.
-# Default is true.
-# allowThroughputOvershoot =
-
-# Lease assignment is performed every failoverTimeMillis but re-balance will
-# be attempted only once in 5 times based on the below config. Default is 3.
-# varianceBalancingFrequency =
-
-# Alpha value used for calculating exponential moving average of worker's metricStats.
-# workerMetricsEMAAlpha =
-# Duration after which workerMetricStats entry from WorkerMetricStats table will
-# be cleaned up.
-# Duration format examples: PT15M (15 mins) PT10H (10 hours) P2D (2 days)
-# Refer to Duration.parse javadocs for more details
-# staleWorkerMetricsEntryCleanupDuration =


### PR DESCRIPTION
1. Upgraded Java KCL dependency
2. Updated sample properties to be up to date
3. removed no longer needed dependencies
4. Added release notes 