### PR TITLE
Release v3.0.2: Update netty.version and fasterxml-jackson version

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ In this release, we have abstracted these implementation details away and expose
 
 ## Release Notes
 
+### Release (v3.0.2 - September 24, 2025)
+* Bump Netty version 4.1.118.Final to version 4.2.4.Final
+* fastxml-jackson version 2.13.5 to version 2.15.0
+
 ### Release (v3.0.1 - May 28, 2025)
 * [#414](https://github.com/awslabs/amazon-kinesis-client-nodejs/pull/414) Bump commons-beanutils:commons-beanutils from 1.9.4 to 1.11.0
 * [#413](https://github.com/awslabs/amazon-kinesis-client-nodejs/pull/413) Bump mocha from 10.4.0 to 11.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-kcl",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-kcl",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "~14.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-kcl",
   "description": "Kinesis Client Libray (KCL) in Node.js.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "http://aws.amazon.com/"

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
     <properties>
         <awssdk.version>2.25.64</awssdk.version>
         <kcl.version>3.0.0</kcl.version>
-        <netty.version>4.1.118.Final</netty.version>
+        <netty.version>4.2.4.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
-        <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
+        <fasterxml-jackson.version>2.15.0</fasterxml-jackson.version>
         <logback.version>1.3.15</logback.version>
     </properties>
     <dependencies>


### PR DESCRIPTION
* Bump Netty version 4.1.118.Final to version 4.2.4.Final
* fastxml-jackson version 2.13.5 to version 2.15.0